### PR TITLE
Adds dependency file server.js to remark-mode recipe

### DIFF
--- a/recipes/remark-mode
+++ b/recipes/remark-mode
@@ -1,1 +1,1 @@
-(remark-mode :fetcher github :repo "torgeir/remark-mode.el" :files (:defaults "remark.html"))
+(remark-mode :fetcher github :repo "torgeir/remark-mode.el" :files (:defaults "remark.html" "server.js"))


### PR DESCRIPTION
### Brief summary of what the package does

No change main package description. This PR merely adds a file that is a new dependency, that removes the package's previous dependency for the npm package `browser-sync` and instead now implements its own server in `server.js` to serve the slideshow to the browser.

### Direct link to the package repository

https://github.com/torgeir/remark-mode.el.

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)